### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "knockout-postbox",
   "version": "0.5.0",
+  "repository": "rniemeyer/knockout-postbox",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-uglify": "0.x.x",


### PR DESCRIPTION
NPM has a [repository field](https://docs.npmjs.com/files/package.json#repository). A warning is displayed during `npm install` if the field is not specified.

```
npm WARN package.json knockout-postbox@0.4.2 No repository field.
```