### PR TITLE
Update package.json for use with Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "type": "git",
     "url": "git://github.com/rniemeyer/knockout-postbox.git"
   },
+  "main": "build/knockout-postbox.js",
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-uglify": "0.x.x",


### PR DESCRIPTION
Make browserify work by adding a "main" entry to package.json. Browserify uses this to figure out how to load the module.

https://www.npmjs.com/package/browserify#package-json